### PR TITLE
Ability to add custom theme, justicehub_theme added

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,11 @@ ckanext-tableview
    What does it do? What features does it have?
    Consider including some screenshots or embedding a video!
 
+Easy to use DataTables plugin in CKAN with different theme to play around with.
+
 Source code for datatables implementation was forked from an official `CKAN Repository <https://github.com/ckan/ckan/tree/ckan-2.8.1/ckanext/datatablesview>`_
+
+.. image:: https://user-images.githubusercontent.com/9320644/95983729-c5408300-0e3f-11eb-9156-d0e2b578bdab.png
 
 ------------
 Requirements
@@ -47,8 +51,19 @@ Configuration
 -------------
 
 ckanext-tableview has inbuilt themes integrated. To use one, add ``justicehub_theme`` to the ``ckan.tableview_theme`` settings in
-your CKAN config file. If not provided, then it will take default theme. In case if theme is not found, then it will
-show: "Internal Server Error" in views section
+your CKAN config file. If not provided, then it will take default theme.
+In case if theme is not found, then it will show: "Internal Server Error" in views section
+
+
+----------------------------
+Adding your own custom theme
+----------------------------
+
+There are mainly 2 steps for adding any custom theme:
+
+1. Add theme name in ``/tableview/public/resource.config`` along with all the resources you want theme to load
+2. Add all relevant css/js files in their respective places inside ``/tableview/public/`` directory anywhere. By default we personally use ``theme`` directory inside ``public`` for custom styles.
+
 
 ------------------------
 Development Installation

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,14 @@ To install ckanext-tableview:
      sudo service apache2 reload
 
 
+-------------
+Configuration
+-------------
+
+ckanext-tableview has inbuilt themes integrated. To use one, add ``justicehub_theme`` to the ``ckan.tableview_theme`` settings in
+your CKAN config file. If not provided, then it will take default theme. In case if theme is not found, then it will
+show: "Internal Server Error" in views section
+
 ------------------------
 Development Installation
 ------------------------

--- a/ckanext/tableview/helpers.py
+++ b/ckanext/tableview/helpers.py
@@ -1,4 +1,4 @@
-from ckan.plugins.toolkit import get_action, ObjectNotFound, NotAuthorized
+from ckan.plugins.toolkit import get_action, ObjectNotFound, NotAuthorized, config
 
 
 def tableview_datastore_dictionary(resource_id):
@@ -12,3 +12,12 @@ def tableview_datastore_dictionary(resource_id):
             if not f['id'].startswith(u'_')]
     except (ObjectNotFound, NotAuthorized):
         return []
+
+
+def tableview_theme():
+    """
+    Return tableview theme string from config file
+    """
+    theme = config.get("ckan.tableview_theme")
+    print("Theme =", theme)
+    return theme if theme else "default_theme"

--- a/ckanext/tableview/helpers.py
+++ b/ckanext/tableview/helpers.py
@@ -19,5 +19,4 @@ def tableview_theme():
     Return tableview theme string from config file
     """
     theme = config.get("ckan.tableview_theme")
-    print("Theme =", theme)
-    return theme if theme else "default_theme"
+    return theme if theme else str(theme)

--- a/ckanext/tableview/plugin.py
+++ b/ckanext/tableview/plugin.py
@@ -48,6 +48,7 @@ class TableView(p.SingletonPlugin):
         from ckanext.tableview import helpers as datatablesview_helpers
         return {
                 'tableview_datastore_dictionary': datatablesview_helpers.tableview_datastore_dictionary,
+                'tableview_theme': datatablesview_helpers.tableview_theme
                 }
 
     def info(self):

--- a/ckanext/tableview/public/resource.config
+++ b/ckanext/tableview/public/resource.config
@@ -31,6 +31,3 @@ main =
 
 justicehub_theme =
     theme/justicehub_theme.css
-
-default_theme =
-    theme/default_theme.css

--- a/ckanext/tableview/public/resource.config
+++ b/ckanext/tableview/public/resource.config
@@ -25,6 +25,7 @@ main =
     vendor/KeyTable-2.2.1/js/dataTables.keyTable.js
     vendor/Responsive-2.1.1/js/dataTables.responsive.js
     vendor/Select-1.2.2/js/dataTables.select.js
+    vendor/ColReorderWithResize.js
 
     datatablesview.js
 

--- a/ckanext/tableview/public/resource.config
+++ b/ckanext/tableview/public/resource.config
@@ -27,3 +27,9 @@ main =
     vendor/Select-1.2.2/js/dataTables.select.js
 
     datatablesview.js
+
+justicehub_theme =
+    theme/justicehub_theme.css
+
+default_theme =
+    theme/default_theme.css

--- a/ckanext/tableview/public/theme/justicehub_theme.css
+++ b/ckanext/tableview/public/theme/justicehub_theme.css
@@ -39,10 +39,6 @@ div.dataTables_wrapper div.dataTables_info {
     border: 0 !important;
 }
 
-.table > thead > tr > th, .table > tbody > tr > th, .table > tfoot > tr > th, .table > thead > tr > td, .table > tbody > tr > td, .table > tfoot > tr > td {
-    line-height: 2.42857143 !important;
-}
-
 .dropdown-menu {
   background-color: #423643 !important;
   margin: -2px 1px !important;
@@ -58,7 +54,9 @@ div.dataTables_wrapper div.dataTables_info {
 }
 
 #dtprv_length {
-  padding-top: 20px;
+  position: absolute;
+  right: 0;
+  margin: 20px;
 }
 
 .dropdown-menu > .active > a, .dropdown-menu > .active > a:hover, .dropdown-menu > .active > a:focus {

--- a/ckanext/tableview/public/theme/justicehub_theme.css
+++ b/ckanext/tableview/public/theme/justicehub_theme.css
@@ -1,0 +1,79 @@
+div.dataTables_wrapper div.dataTables_paginate {
+    margin: 20px 0 !important;
+    text-align: left !important;
+}
+
+div.dataTables_wrapper div.dataTables_filter {
+    text-align: left !important;
+    margin: 20px 0 !important;
+}
+
+#dtprv_info {
+  display: none;
+}
+
+div.dataTables_wrapper div.dataTables_info {
+    font-size: 13px;
+}
+
+.table-bordered > thead > tr > th, .table-bordered > tbody > tr > th, .table-bordered > tfoot > tr > th, .table-bordered > thead > tr > td, .table-bordered > tbody > tr > td, .table-bordered > tfoot > tr > td {
+  border: 0 !important;
+}
+
+.table-bordered {
+    border: 0 !important;
+}
+
+.table > thead > tr > th, .table > tbody > tr > th, .table > tfoot > tr > th, .table > thead > tr > td, .table > tbody > tr > td, .table > tfoot > tr > td {
+    line-height: 2.42857143 !important;
+}
+
+.dropdown-menu {
+  background-color: #423643 !important;
+  margin: -2px 1px !important;
+  color: white !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+}
+
+.buttons-colvis {
+    background-color: #423643 !important;
+    color: white !important;
+    border-color: none !important;
+}
+
+#dtprv_length {
+  padding-top: 20px;
+}
+
+.dropdown-menu > .active > a, .dropdown-menu > .active > a:hover, .dropdown-menu > .active > a:focus {
+    background-color: #423643 !important;
+    color: white !important;
+}
+
+.dropdown-menu > li > a {
+    color: gray !important;
+}
+
+.pagination > .active > a, .pagination > .active > span, .pagination > .active > a:hover, .pagination > .active > span:hover, .pagination > .active > a:focus, .pagination > .active > span:focus {
+    border-color: #423643 !important;
+    background-color: #423643 !important;
+    color: white !important;
+}
+
+.pagination > li > a, .pagination > li > span {
+    color: #423643 !important;
+}
+
+tbody tr:hover {
+      background-color: #a9b7d1 !important; }
+
+.DTFC_Cloned {
+  width: 95% !important;
+}
+
+.dt-buttons {
+  position: absolute !important;
+  right: 0;
+  padding: 20px;
+}

--- a/ckanext/tableview/public/theme/justicehub_theme.css
+++ b/ckanext/tableview/public/theme/justicehub_theme.css
@@ -1,3 +1,19 @@
+.dataTables_wrapper {
+  margin: 2%;
+}
+
+.DTFC_LeftHeadWrapper {
+    border-bottom: 2px solid black !important;
+}
+
+div.dataTables_scrollBody > table {
+    border-bottom: 2px solid black !important;
+}
+
+div.dataTables_scrollHead table.table-bordered {
+    border-bottom: 2px solid black !important;
+}
+
 div.dataTables_wrapper div.dataTables_paginate {
     margin: 20px 0 !important;
     text-align: left !important;
@@ -5,7 +21,6 @@ div.dataTables_wrapper div.dataTables_paginate {
 
 div.dataTables_wrapper div.dataTables_filter {
     text-align: left !important;
-    margin: 20px 0 !important;
 }
 
 #dtprv_info {
@@ -13,7 +28,7 @@ div.dataTables_wrapper div.dataTables_filter {
 }
 
 div.dataTables_wrapper div.dataTables_info {
-    font-size: 13px;
+    font-size: 11px;
 }
 
 .table-bordered > thead > tr > th, .table-bordered > tbody > tr > th, .table-bordered > tfoot > tr > th, .table-bordered > thead > tr > td, .table-bordered > tbody > tr > td, .table-bordered > tfoot > tr > td {
@@ -74,6 +89,7 @@ tbody tr:hover {
 
 .dt-buttons {
   position: absolute !important;
+  top: 0;
   right: 0;
   padding: 20px;
 }

--- a/ckanext/tableview/public/vendor/ColReorderWithResize.js
+++ b/ckanext/tableview/public/vendor/ColReorderWithResize.js
@@ -1,0 +1,1759 @@
+/**
+ * @license
+ * File:        ColReorderWithResize.js
+ * Version:     3.0
+ * CVS:         $Id$
+ * Description: Allow columns to be reordered in a DataTable
+ * Author:      Allan Jardine (www.sprymedia.co.uk)
+ * Author:      Christophe Battarel (www.altairis.fr)
+ * Created:     Wed Sep 15 18:23:29 BST 2010
+ * Modified:    July 2011 by Christophe Battarel - christophe.battarel@altairis.fr (columns resizable)
+ * Modified:    February 2012 by Martin Marchetta - martin.marchetta@gmail.com
+ *  1. Made the "hot area" for resizing a little wider (it was a little difficult to hit the exact border of a column for resizing)
+ *  2. Resizing didn't work at all when using scroller (that plugin splits the table into 2 different tables: one for the header and another one for the body, so when you resized the header, the data columns didn't follow)
+ *  3. Fixed collateral effects of sorting feature
+ *  4. If sScrollX is enabled (i.e. horizontal scrolling), when resizing a column the width of the other columns is not changed, but the whole
+ *     table is resized to give an Excel-like behavior (good suggestion by Allan)
+ * Modified:    February 2012 by Christophe Battarel - christophe.battarel@altairis.fr (ColReorder v1.0.5 adaptation)
+ * Modified:    September 16th 2012 by Hassan Kamara - h@phrmc.com
+ * Modified:    June 2017 by Jeff Walter - jeffreydwalter@gmail.com
+ *  1. ColReorder v1.3.3 adaptation.
+ *  2. Fixed issues with column width calculations which allowed column headers to become misaligned with table body when using scroller plugin.
+ * Modified:    June 2018 by Jeff Walter - jeffreydwalter@gmail.com
+ *  1. Took a second stab at this plugin. Made things work for both scroller and non-scroller tables.
+ * Language:    Javascript
+ * License:     MIT
+ * Project:     DataTables
+ *
+ */
+
+(function( factory ){
+    if ( typeof define === 'function' && define.amd ) {
+        // AMD
+        define( ['jquery', 'datatables.net'], function ( $ ) {
+            return factory( $, window, document );
+        } );
+    }
+    else if ( typeof exports === 'object' ) {
+        // CommonJS
+        module.exports = function (root, $) {
+            if ( ! root ) {
+                root = window;
+            }
+
+            if ( ! $ || ! $.fn.dataTable ) {
+                $ = require('datatables.net')(root, $).$;
+            }
+
+            return factory( $, root, root.document );
+        };
+    }
+    else {
+        // Browser
+        factory( jQuery, window, document );
+    }
+}(function( $, window, document, undefined ) {
+'use strict';
+var DataTable = $.fn.dataTable;
+
+
+
+/**
+ * Switch the key value pairing of an index array to be value key (i.e. the old value is now the
+ * key). For example consider [ 2, 0, 1 ] this would be returned as [ 1, 2, 0 ].
+ *  @method  fnInvertKeyValues
+ *  @param   array aIn Array to switch around
+ *  @returns array
+ */
+function fnInvertKeyValues( aIn )
+{
+    var aRet=[];
+    for ( var i=0, iLen=aIn.length ; i<iLen ; i++ )
+    {
+        aRet[ aIn[i] ] = i;
+    }
+    return aRet;
+}
+
+/**
+ * Modify an array by switching the position of two elements
+ *  @method  fnArraySwitch
+ *  @param   array aArray Array to consider, will be modified by reference (i.e. no return)
+ *  @param   int iFrom From point
+ *  @param   int iTo Insert point
+ *  @returns void
+ */
+function fnArraySwitch( aArray, iFrom, iTo )
+{
+    var mStore = aArray.splice( iFrom, 1 )[0];
+    aArray.splice( iTo, 0, mStore );
+}
+
+/**
+ * Switch the positions of nodes in a parent node (note this is specifically designed for
+ * table rows). Note this function considers all element nodes under the parent!
+ *  @method  fnDomSwitch
+ *  @param   string sTag Tag to consider
+ *  @param   int iFrom Element to move
+ *  @param   int Point to element the element to (before this point), can be null for append
+ *  @returns void
+ */
+function fnDomSwitch( nParent, iFrom, iTo )
+{
+    var anTags = [];
+    for ( var i=0, iLen=nParent.childNodes.length ; i<iLen ; i++ )
+    {
+        if ( nParent.childNodes[i].nodeType == 1 )
+        {
+            anTags.push( nParent.childNodes[i] );
+        }
+    }
+    var nStore = anTags[ iFrom ];
+
+    if ( iTo !== null )
+    {
+        nParent.insertBefore( nStore, anTags[iTo] );
+    }
+    else
+    {
+        nParent.appendChild( nStore );
+    }
+}
+
+/**
+ * Plug-in for DataTables which will reorder the internal column structure by taking the column
+ * from one position (iFrom) and insert it into a given point (iTo).
+ *  @method  $.fn.dataTableExt.oApi.fnColReorder
+ *  @param   object oSettings DataTables settings object - automatically added by DataTables!
+ *  @param   int iFrom Take the column to be repositioned from this point
+ *  @param   int iTo and insert it into this point
+ *  @param   bool drop Indicate if the reorder is the final one (i.e. a drop)
+ *    not a live reorder
+ *  @param   bool invalidateRows speeds up processing if false passed
+ *  @returns void
+ */
+$.fn.dataTableExt.oApi.fnColReorder = function ( oSettings, iFrom, iTo, drop, invalidateRows )
+{
+    var i, iLen, j, jLen, jen, iCols=oSettings.aoColumns.length, nTrs, oCol;
+    var attrMap = function ( obj, prop, mapping ) {
+        if ( ! obj[ prop ] || typeof obj[ prop ] === 'function' ) {
+            return;
+        }
+
+        var a = obj[ prop ].split('.');
+        var num = a.shift();
+
+        if ( isNaN( num*1 ) ) {
+            return;
+        }
+
+        obj[ prop ] = mapping[ num*1 ]+'.'+a.join('.');
+    };
+
+    /* Sanity check in the input */
+    if ( iFrom == iTo )
+    {
+        /* Pointless reorder */
+        return;
+    }
+
+    if ( iFrom < 0 || iFrom >= iCols )
+    {
+        this.oApi._fnLog( oSettings, 1, "ColReorder 'from' index is out of bounds: "+iFrom );
+        return;
+    }
+
+    if ( iTo < 0 || iTo >= iCols )
+    {
+        this.oApi._fnLog( oSettings, 1, "ColReorder 'to' index is out of bounds: "+iTo );
+        return;
+    }
+
+    /*
+     * Calculate the new column array index, so we have a mapping between the old and new
+     */
+    var aiMapping = [];
+    for ( i=0, iLen=iCols ; i<iLen ; i++ )
+    {
+        aiMapping[i] = i;
+    }
+    fnArraySwitch( aiMapping, iFrom, iTo );
+    var aiInvertMapping = fnInvertKeyValues( aiMapping );
+
+
+    /*
+     * Convert all internal indexing to the new column order indexes
+     */
+    /* Sorting */
+    for ( i=0, iLen=oSettings.aaSorting.length ; i<iLen ; i++ )
+    {
+        oSettings.aaSorting[i][0] = aiInvertMapping[ oSettings.aaSorting[i][0] ];
+    }
+
+    /* Fixed sorting */
+    if ( oSettings.aaSortingFixed !== null )
+    {
+        for ( i=0, iLen=oSettings.aaSortingFixed.length ; i<iLen ; i++ )
+        {
+            oSettings.aaSortingFixed[i][0] = aiInvertMapping[ oSettings.aaSortingFixed[i][0] ];
+        }
+    }
+
+    /* Data column sorting (the column which the sort for a given column should take place on) */
+    for ( i=0, iLen=iCols ; i<iLen ; i++ )
+    {
+        oCol = oSettings.aoColumns[i];
+        for ( j=0, jLen=oCol.aDataSort.length ; j<jLen ; j++ )
+        {
+            oCol.aDataSort[j] = aiInvertMapping[ oCol.aDataSort[j] ];
+        }
+
+        // Update the column indexes
+        oCol.idx = aiInvertMapping[ oCol.idx ];
+    }
+
+    // Update 1.10 optimised sort class removal variable
+    $.each( oSettings.aLastSort, function (i, val) {
+        oSettings.aLastSort[i].src = aiInvertMapping[ val.src ];
+    } );
+
+    /* Update the Get and Set functions for each column */
+    for ( i=0, iLen=iCols ; i<iLen ; i++ )
+    {
+        oCol = oSettings.aoColumns[i];
+
+        if ( typeof oCol.mData == 'number' ) {
+            oCol.mData = aiInvertMapping[ oCol.mData ];
+        }
+        else if ( $.isPlainObject( oCol.mData ) ) {
+            // HTML5 data sourced
+            attrMap( oCol.mData, '_',      aiInvertMapping );
+            attrMap( oCol.mData, 'filter', aiInvertMapping );
+            attrMap( oCol.mData, 'sort',   aiInvertMapping );
+            attrMap( oCol.mData, 'type',   aiInvertMapping );
+        }
+    }
+
+    /*
+     * Move the DOM elements
+     */
+    if ( oSettings.aoColumns[iFrom].bVisible )
+    {
+        /* Calculate the current visible index and the point to insert the node before. The insert
+         * before needs to take into account that there might not be an element to insert before,
+         * in which case it will be null, and an appendChild should be used
+         */
+        var iVisibleIndex = this.oApi._fnColumnIndexToVisible( oSettings, iFrom );
+        var iInsertBeforeIndex = null;
+
+        i = iTo < iFrom ? iTo : iTo + 1;
+        while ( iInsertBeforeIndex === null && i < iCols )
+        {
+            iInsertBeforeIndex = this.oApi._fnColumnIndexToVisible( oSettings, i );
+            i++;
+        }
+
+        /* Header */
+        nTrs = oSettings.nTHead.getElementsByTagName('tr');
+        for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
+        {
+            fnDomSwitch( nTrs[i], iVisibleIndex, iInsertBeforeIndex );
+        }
+
+        /* Footer */
+        if ( oSettings.nTFoot !== null )
+        {
+            nTrs = oSettings.nTFoot.getElementsByTagName('tr');
+            for ( i=0, iLen=nTrs.length ; i<iLen ; i++ )
+            {
+                fnDomSwitch( nTrs[i], iVisibleIndex, iInsertBeforeIndex );
+            }
+        }
+
+        /* Body */
+        for ( i=0, iLen=oSettings.aoData.length ; i<iLen ; i++ )
+        {
+            if ( oSettings.aoData[i].nTr !== null )
+            {
+                fnDomSwitch( oSettings.aoData[i].nTr, iVisibleIndex, iInsertBeforeIndex );
+            }
+        }
+    }
+
+    /*
+     * Move the internal array elements
+     */
+    /* Columns */
+    fnArraySwitch( oSettings.aoColumns, iFrom, iTo );
+
+    // regenerate the get / set functions
+    for ( i=0, iLen=iCols ; i<iLen ; i++ ) {
+        oSettings.oApi._fnColumnOptions( oSettings, i, {} );
+    }
+
+    /* Search columns */
+    fnArraySwitch( oSettings.aoPreSearchCols, iFrom, iTo );
+
+    /* Array array - internal data anodes cache */
+    for ( i=0, iLen=oSettings.aoData.length ; i<iLen ; i++ )
+    {
+        var data = oSettings.aoData[i];
+        var cells = data.anCells;
+
+        if ( cells ) {
+            fnArraySwitch( cells, iFrom, iTo );
+
+            // Longer term, should this be moved into the DataTables' invalidate
+            // methods?
+            for ( j=0, jen=cells.length ; j<jen ; j++ ) {
+                if ( cells[j] && cells[j]._DT_CellIndex ) {
+                    cells[j]._DT_CellIndex.column = j;
+                }
+            }
+        }
+
+        // For DOM sourced data, the invalidate will reread the cell into
+        // the data array, but for data sources as an array, they need to
+        // be flipped
+        if ( data.src !== 'dom' && $.isArray( data._aData ) ) {
+            fnArraySwitch( data._aData, iFrom, iTo );
+        }
+    }
+
+    /* Reposition the header elements in the header layout array */
+    for ( i=0, iLen=oSettings.aoHeader.length ; i<iLen ; i++ )
+    {
+        fnArraySwitch( oSettings.aoHeader[i], iFrom, iTo );
+    }
+
+    if ( oSettings.aoFooter !== null )
+    {
+        for ( i=0, iLen=oSettings.aoFooter.length ; i<iLen ; i++ )
+        {
+            fnArraySwitch( oSettings.aoFooter[i], iFrom, iTo );
+        }
+    }
+
+    if ( invalidateRows || invalidateRows === undefined )
+    {
+        $.fn.dataTable.Api( oSettings ).rows().invalidate();
+    }
+
+    /*
+     * Update DataTables' event handlers
+     */
+
+    /* Sort listener */
+    for ( i=0, iLen=iCols ; i<iLen ; i++ )
+    {
+        $(oSettings.aoColumns[i].nTh).off('click.DT');
+        this.oApi._fnSortAttachListener( oSettings, oSettings.aoColumns[i].nTh, i );
+    }
+
+    /* Fire an event so other plug-ins can update */
+    $(oSettings.oInstance).trigger( 'column-reorder.dt', [ oSettings, {
+        from: iFrom,
+        to: iTo,
+        mapping: aiInvertMapping,
+        drop: drop,
+
+        // Old style parameters for compatibility
+        iFrom: iFrom,
+        iTo: iTo,
+        aiInvertMapping: aiInvertMapping
+    } ] );
+};
+
+/**
+ * ColReorder provides column visibility control for DataTables
+ * @class ColReorder
+ * @constructor
+ * @param {object} dt DataTables settings object
+ * @param {object} opts ColReorder options
+ */
+var ColReorder = function( dt, opts )
+{
+    var settings = new $.fn.dataTable.Api( dt ).settings()[0];
+
+    // Ensure that we can't initialise on the same table twice
+    if ( settings._colReorder ) {
+        return settings._colReorder;
+    }
+
+    // Allow the options to be a boolean for defaults
+    if ( opts === true ) {
+        opts = {};
+    }
+
+    // Convert from camelCase to Hungarian, just as DataTables does
+    var camelToHungarian = $.fn.dataTable.camelToHungarian;
+    if ( camelToHungarian ) {
+        camelToHungarian( ColReorder.defaults, ColReorder.defaults, true );
+        camelToHungarian( ColReorder.defaults, opts || {} );
+    }
+
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+     * Public class variables
+     * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+    /**
+     * @namespace Settings object which contains customisable information for ColReorder instance
+     */
+    this.s = {
+        /**
+         * DataTables settings object
+         *  @property dt
+         *  @type     Object
+         *  @default  null
+         */
+        "dt": null,
+
+        /**
+         * Initialisation object used for this instance
+         *  @property init
+         *  @type     object
+         *  @default  {}
+         */
+        "init": $.extend( true, {}, ColReorder.defaults, opts ),
+
+        /**
+         * Allow Reorder functionnality
+         *  @property allowReorder
+         *  @type     boolean
+         *  @default  true
+         */
+        "allowReorder": true,
+
+        /**
+         * Allow Resize functionnality
+         *  @property allowResize
+         *  @type     boolean
+         *  @default  true
+         */
+        "allowResize": true,
+
+        /**
+         * Number of columns to fix (not allow to be reordered)
+         *  @property fixed
+         *  @type     int
+         *  @default  0
+         */
+        "fixed": 0,
+
+        /**
+         * Number of columns to fix counting from right (not allow to be reordered)
+         *  @property fixedRight
+         *  @type     int
+         *  @default  0
+         */
+        "fixedRight": 0,
+
+        /**
+         * Callback function for once the reorder has been done
+         *  @property reorderCallback
+         *  @type     function
+         *  @default  null
+         */
+        "reorderCallback": null,
+
+        /**
+         * Callback function for once the resize has been done
+         *  @property resizeCallback
+         *  @type     function
+         *  @default  null
+         */
+        "resizeCallback": null,
+
+        /**
+         * @namespace Information used for the mouse drag
+         */
+        "mouse": {
+            "startX": -1,
+            "startY": -1,
+            "offsetX": -1,
+            "offsetY": -1,
+            "target": -1,
+            "targetIndex": -1,
+            "fromIndex": -1
+        },
+
+        /**
+         * Information which is used for positioning the insert cusor and knowing where to do the
+         * insert. Array of objects with the properties:
+         *   x: x-axis position
+         *   to: insert point
+         *  @property aoTargets
+         *  @type     array
+         *  @default  []
+         */
+        "aoTargets": []
+    };
+
+
+    /**
+     * @namespace Common and useful DOM elements for the class instance
+     */
+    this.dom = {
+        /**
+         * Dragging element (the one the mouse is moving)
+         *  @property drag
+         *  @type     element
+         *  @default  null
+         */
+        "drag": null,
+
+        /**
+         * Resizing a column
+         *  @property drag
+         *  @type     element
+         *  @default  null
+         */
+        "resize": null,
+
+        /**
+         * The insert cursor
+         *  @property pointer
+         *  @type     element
+         *  @default  null
+         */
+        "pointer": null
+    };
+
+    /* Constructor logic */
+    this.s.dt = settings;
+
+    // Keep the current table's size in order to resize it if columns are resized and scrollX is enabled.
+    if(this.s.dt.oInit.sScrollX === undefined) {
+        this.table_size = -1;
+    }
+
+    this.s.dt._colReorder = this;
+    this._fnConstruct();
+
+    return this;
+};
+
+
+
+$.extend( ColReorder.prototype, {
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+     * Public methods
+     * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+    /**
+     * Reset the column ordering to the original ordering that was detected on
+     * start up.
+     *  @return {this} Returns `this` for chaining.
+     *
+     *  @example
+     *    // DataTables initialisation with ColReorder
+     *    var table = $('#example').dataTable( {
+     *        "sDom": 'Rlfrtip'
+     *    } );
+     *
+     *    // Add click event to a button to reset the ordering
+     *    $('#resetOrdering').click( function (e) {
+     *        e.preventDefault();
+     *        $.fn.dataTable.ColReorder( table ).fnReset();
+     *    } );
+     */
+    "fnReset": function ()
+    {
+        this._fnOrderColumns( this.fnOrder() );
+
+        return this;
+    },
+
+    /**
+     * `Deprecated` - Get the current order of the columns, as an array.
+     *  @return {array} Array of column identifiers
+     *  @deprecated `fnOrder` should be used in preference to this method.
+     *      `fnOrder` acts as a getter/setter.
+     */
+    "fnGetCurrentOrder": function ()
+    {
+        return this.fnOrder();
+    },
+
+    /**
+     * Get the current order of the columns, as an array. Note that the values
+     * given in the array are unique identifiers for each column. Currently
+     * these are the original ordering of the columns that was detected on
+     * start up, but this could potentially change in future.
+     *  @return {array} Array of column identifiers
+     *
+     *  @example
+     *    // Get column ordering for the table
+     *    var order = $.fn.dataTable.ColReorder( dataTable ).fnOrder();
+     *//**
+     * Set the order of the columns, from the positions identified in the
+     * ordering array given. Note that ColReorder takes a brute force approach
+     * to reordering, so it is possible multiple reordering events will occur
+     * before the final order is settled upon.
+     *  @param {array} [set] Array of column identifiers in the new order. Note
+     *    that every column must be included, uniquely, in this array.
+     *  @return {this} Returns `this` for chaining.
+     *
+     *  @example
+     *    // Swap the first and second columns
+     *    $.fn.dataTable.ColReorder( dataTable ).fnOrder( [1, 0, 2, 3, 4] );
+     *
+     *  @example
+     *    // Move the first column to the end for the table `#example`
+     *    var curr = $.fn.dataTable.ColReorder( '#example' ).fnOrder();
+     *    var first = curr.shift();
+     *    curr.push( first );
+     *    $.fn.dataTable.ColReorder( '#example' ).fnOrder( curr );
+     *
+     *  @example
+     *    // Reverse the table's order
+     *    $.fn.dataTable.ColReorder( '#example' ).fnOrder(
+     *      $.fn.dataTable.ColReorder( '#example' ).fnOrder().reverse()
+     *    );
+     */
+    "fnOrder": function ( set, original )
+    {
+        var a = [], i, ien, j, jen;
+        var columns = this.s.dt.aoColumns;
+
+        if ( set === undefined ){
+            for ( i=0, ien=columns.length ; i<ien ; i++ ) {
+                a.push( columns[i]._ColReorder_iOrigCol );
+            }
+
+            return a;
+        }
+
+        // The order given is based on the original indexes, rather than the
+        // existing ones, so we need to translate from the original to current
+        // before then doing the order
+        if ( original ) {
+            var order = this.fnOrder();
+
+            for ( i=0, ien=set.length ; i<ien ; i++ ) {
+                a.push( $.inArray( set[i], order ) );
+            }
+
+            set = a;
+        }
+
+        this._fnOrderColumns( fnInvertKeyValues( set ) );
+
+        return this;
+    },
+
+    /**
+     * Convert from the original column index, to the original
+     *
+     * @param  {int|array} idx Index(es) to convert
+     * @param  {string} dir Transpose direction - `fromOriginal` / `toCurrent`
+     *   or `'toOriginal` / `fromCurrent`
+     * @return {int|array}     Converted values
+     */
+    fnTranspose: function ( idx, dir )
+    {
+        if ( ! dir ) {
+            dir = 'toCurrent';
+        }
+
+        var order = this.fnOrder();
+        var columns = this.s.dt.aoColumns;
+
+        if ( dir === 'toCurrent' ) {
+            // Given an original index, want the current
+            return ! $.isArray( idx ) ?
+                $.inArray( idx, order ) :
+                $.map( idx, function ( index ) {
+                    return $.inArray( index, order );
+                } );
+        }
+        else {
+            // Given a current index, want the original
+            return ! $.isArray( idx ) ?
+                columns[idx]._ColReorder_iOrigCol :
+                $.map( idx, function ( index ) {
+                    return columns[index]._ColReorder_iOrigCol;
+                } );
+        }
+    },
+
+
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+     * Private methods (they are of course public in JS, but recommended as private)
+     * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+    /**
+     * Constructor logic
+     *  @method  _fnConstruct
+     *  @returns void
+     *  @private
+     */
+    "_fnConstruct": function ()
+    {
+        var that = this;
+        var iLen = this.s.dt.aoColumns.length;
+        var table = this.s.dt.nTable;
+        var i;
+
+        /* allow reorder */
+        if ( this.s.init.allowReorder != undefined)
+        {
+            this.s.allowReorder = this.s.init.allowReorder;
+        }
+
+        /* allow resize */
+        if ( this.s.init.allowResize != undefined )
+        {
+            this.s.allowResize = this.s.init.allowResize;
+        }
+
+        /* Columns discounted from reordering - counting left to right */
+        if ( this.s.init.iFixedColumns )
+        {
+            this.s.fixed = this.s.init.iFixedColumns;
+        }
+
+        if ( this.s.init.iFixedColumnsLeft )
+        {
+            this.s.fixed = this.s.init.iFixedColumnsLeft;
+        }
+
+        /* Classnames added to elements */
+        if ( this.s.init.classNameClonedTable )
+        {
+            this.s.classNameClonedTable = this.s.init.classNameClonedTable;
+        }
+
+        if ( this.s.init.classNamePointer )
+        {
+            this.s.classNamePointer = this.s.init.classNamePointer;
+        }
+
+        if ( this.s.init.classNameTableHeader )
+        {
+            this.s.classNameTableHeader = this.s.init.classNameTableHeader;
+        }
+
+        if ( this.s.init.classNameTableHeaderHover )
+        {
+            this.s.classNameTableHeaderHover = this.s.init.classNameTableHeaderHover;
+        }
+
+        /* Columns discounted from reordering - counting right to left */
+        this.s.fixedRight = this.s.init.iFixedColumnsRight ?
+            this.s.init.iFixedColumnsRight :
+            0;
+
+        /* Drop callback initialisation option */
+        if ( this.s.init.fnReorderCallback )
+        {
+            this.s.reorderCallback = this.s.init.fnReorderCallback;
+        }
+
+        /* Reorder callback initialisation option */
+        if ( this.s.init.fnResizeCallback )
+        {
+            this.s.resizeCallback = this.s.init.fnResizeCallback;
+        }
+
+        /* Add event handlers for the drag and drop, and also mark the original column order */
+        for ( i = 0; i < iLen; i++ )
+        {
+            if ( i > this.s.fixed-1 && i < iLen - this.s.fixedRight )
+            {
+                this._fnMouseListener( i, this.s.dt.aoColumns[i].nTh );
+            }
+
+            /* Mark the original column order for later reference */
+            this.s.dt.aoColumns[i]._ColReorder_iOrigCol = i;
+        }
+
+        /* State saving */
+        this.s.dt.oApi._fnCallbackReg( this.s.dt, 'aoStateSaveParams', function (oS, oData) {
+            that._fnStateSave.call( that, oData );
+        }, "ColReorder_State" );
+
+        /* An initial column order has been specified */
+        var aiOrder = null;
+        if ( this.s.init.aiOrder )
+        {
+            aiOrder = this.s.init.aiOrder.slice();
+        }
+
+        /* State loading, overrides the column order given */
+        if ( this.s.dt.oLoadedState && typeof this.s.dt.oLoadedState.ColReorder != 'undefined' &&
+          this.s.dt.oLoadedState.ColReorder.length == this.s.dt.aoColumns.length )
+        {
+            aiOrder = this.s.dt.oLoadedState.ColReorder;
+        }
+
+                /* If we have an order to apply - do so */
+        if ( aiOrder )
+        {
+            /* We might be called during or after the DataTables initialisation. If before, then we need
+             * to wait until the draw is done, if after, then do what we need to do right away
+             */
+            if ( !that.s.dt._bInitComplete )
+            {
+                var bDone = false;
+                $(table).on( 'draw.dt.colReorder', function () {
+                    if ( !that.s.dt._bInitComplete && !bDone )
+                    {
+                        bDone = true;
+                        var resort = fnInvertKeyValues( aiOrder );
+                        that._fnOrderColumns.call( that, resort );
+                    }
+                } );
+            }
+            else
+            {
+                var resort = fnInvertKeyValues( aiOrder );
+                that._fnOrderColumns.call( that, resort );
+            }
+        }
+        else {
+            this._fnSetColumnIndexes();
+        }
+
+        // Destroy clean up
+        $(table).on( 'destroy.dt.colReorder', function () {
+            $(table).off( 'destroy.dt.colReorder draw.dt.colReorder' );
+            $(that.s.dt.nTHead).find( '*' ).off( '.ColReorder' );
+
+            $.each( that.s.dt.aoColumns, function (i, column) {
+                $(column.nTh).removeAttr('data-column-index');
+            } );
+
+            that.s.dt._colReorder = null;
+            that.s = null;
+        } );
+    },
+
+
+    /**
+     * Set the column order from an array
+     *  @method  _fnOrderColumns
+     *  @param   array a An array of integers which dictate the column order that should be applied
+     *  @returns void
+     *  @private
+     */
+    "_fnOrderColumns": function ( a )
+    {
+        var changed = false;
+
+        if ( a.length != this.s.dt.aoColumns.length )
+        {
+            this.s.dt.oInstance.oApi._fnLog( this.s.dt, 1, "ColReorder - array reorder does not "+
+                "match known number of columns. Skipping." );
+            return;
+        }
+
+        for ( var i=0, iLen=a.length ; i<iLen ; i++ )
+        {
+            var currIndex = $.inArray( i, a );
+            if ( i != currIndex )
+            {
+                /* Reorder our switching array */
+                fnArraySwitch( a, currIndex, i );
+
+                /* Do the column reorder in the table */
+                this.s.dt.oInstance.fnColReorder( currIndex, i, true, false );
+
+                changed = true;
+            }
+        }
+
+        $.fn.dataTable.Api( this.s.dt ).rows().invalidate();
+
+        this._fnSetColumnIndexes();
+
+        // Has anything actually changed? If not, then nothing else to do
+        if ( ! changed ) {
+            return;
+        }
+
+        /* When scrolling we need to recalculate the column sizes to allow for the shift */
+        if ( this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "" )
+        {
+            this.s.dt.oInstance.fnAdjustColumnSizing( false );
+        }
+
+        /* Save the state */
+        this.s.dt.oInstance.oApi._fnSaveState( this.s.dt );
+
+        if ( this.s.reorderCallback !== null )
+        {
+            this.s.reorderCallback.call( this );
+        }
+    },
+
+
+    /**
+     * Because we change the indexes of columns in the table, relative to their starting point
+     * we need to reorder the state columns to what they are at the starting point so we can
+     * then rearrange them again on state load!
+     *  @method  _fnStateSave
+     *  @param   object oState DataTables state
+     *  @returns string JSON encoded cookie string for DataTables
+     *  @private
+     */
+    "_fnStateSave": function ( oState )
+    {
+        var i, iLen, aCopy, iOrigColumn;
+        var oSettings = this.s.dt;
+        var columns = oSettings.aoColumns;
+
+        oState.ColReorder = [];
+
+        /* Sorting */
+        if ( oState.aaSorting ) {
+            // 1.10.0-
+            for ( i=0 ; i<oState.aaSorting.length ; i++ ) {
+                oState.aaSorting[i][0] = columns[ oState.aaSorting[i][0] ]._ColReorder_iOrigCol;
+            }
+
+            var aSearchCopy = $.extend( true, [], oState.aoSearchCols );
+
+            for ( i=0, iLen=columns.length ; i<iLen ; i++ )
+            {
+                iOrigColumn = columns[i]._ColReorder_iOrigCol;
+
+                /* Column filter */
+                oState.aoSearchCols[ iOrigColumn ] = aSearchCopy[i];
+
+                /* Visibility */
+                oState.abVisCols[ iOrigColumn ] = columns[i].bVisible;
+
+                /* Column reordering */
+                oState.ColReorder.push( iOrigColumn );
+            }
+        }
+        else if ( oState.order ) {
+            // 1.10.1+
+            for ( i=0 ; i<oState.order.length ; i++ ) {
+                oState.order[i][0] = columns[ oState.order[i][0] ]._ColReorder_iOrigCol;
+            }
+
+            var stateColumnsCopy = $.extend( true, [], oState.columns );
+
+            for ( i=0, iLen=columns.length ; i<iLen ; i++ )
+            {
+                iOrigColumn = columns[i]._ColReorder_iOrigCol;
+
+                /* Columns */
+                oState.columns[ iOrigColumn ] = stateColumnsCopy[i];
+
+                /* Column reordering */
+                oState.ColReorder.push( iOrigColumn );
+            }
+        }
+    },
+
+
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+     * Mouse drop and drag
+     */
+
+    /**
+     * Add a mouse down listener to a particluar TH element
+     *  @method  _fnMouseListener
+     *  @param   int i Column index
+     *  @param   element nTh TH element clicked on
+     *  @returns void
+     *  @private
+     */
+    "_fnMouseListener": function ( i, nTh )
+    {
+        var that = this;
+        var aoColumns = this.s.dt.aoColumns;
+        var bSort =  that.s.dt.oFeatures.bSort
+
+        var tableHeaderHoverClassname =  this.s.classNameTableHeaderHover;
+        var tableHeaderClassname =  this.s.classNameTableHeader;
+
+        // Rebind events since after column re-order they use wrong column indices.
+        $(nTh).off('.ColReorder');
+
+        // listen to mousemove event for resize
+        if (this.s.allowResize) {
+            $(nTh).on( 'mousemove.ColReorder', function (e) {
+                if (that.dom.drag === null && that.dom.resize === null)
+                {
+                    /* Store information about the mouse position */
+                    var nThTarget = e.target.nodeName == "TH" ? e.target : $(e.target).parents('TH')[0];
+                    var offset = $(nThTarget).offset();
+                    var nLength = $(nThTarget).innerWidth();
+
+                    /* are we on the col border (if so, resize col) */
+                    if (Math.abs(e.pageX - Math.round(offset.left + nLength)) <= 5)
+                    {
+                        $(nThTarget).css({'cursor': 'col-resize'});
+                        $(nThTarget).removeClass( tableHeaderClassname );
+                        $(nThTarget).addClass( tableHeaderHoverClassname );
+                    }
+                    else {
+                        $(nThTarget).css({'cursor': 'pointer'});
+                        $(nThTarget).removeClass( tableHeaderHoverClassname );
+                        $(nThTarget).addClass( tableHeaderClassname );
+                    }
+                }
+            } );
+        }
+
+        $(nTh)
+            .on( 'mousedown.ColReorder', function (e) {
+                e.preventDefault();
+                if (e.which == 1) {
+                    that._fnMouseDown.call( that, e, nTh, i );
+                }
+            } )
+            .on( 'touchstart.ColReorder', function (e) {
+                that._fnMouseDown.call( that, e, nTh, i );
+            } );
+    },
+
+
+    /**
+     * Mouse down on a TH element in the table header
+     *  @method  _fnMouseDown
+     *  @param   event e Mouse event
+     *  @param   element nTh TH element to be dragged
+     *  @param      i The column that's resized/dragged
+     *  @returns void
+     *  @private
+     */
+    "_fnMouseDown": function ( e, nTh, i )
+    {
+        var
+            that = this,
+        aoColumns = this.s.dt.aoColumns;
+
+
+        function addEventsHandler() {
+          /* Add event handlers to the document */
+          $(document)
+              .on( 'mousemove.ColReorder touchmove.ColReorder', function (e) {
+                  // Added index of the call being dragged or resized.
+                  that._fnMouseMove.call( that, e, i);
+              } )
+              .on( 'mouseup.ColReorder touchend.ColReorder', function (e) {
+                  // Added this small delay in order to prevent collision with column sort feature (there must be a better
+                  // way of doing this, but I don't have more time to digg into it).
+                  setTimeout(function() { that._fnMouseUp.call( that, e, i ); }, 10);
+              } );
+        }
+
+        /* are we resizing a column ? */
+        if ($(nTh).css('cursor') == 'col-resize') {
+            this.s.mouse.startX = e.pageX;
+            this.s.mouse.startWidth = $(nTh).width();
+            this.s.mouse.resizeElem = $(nTh);
+
+            var nThNext = $(nTh).next();
+            this.s.mouse.nextStartWidth = $(nThNext).width();
+            that.dom.resize = true;
+            // Disable column sorting in order to avoid issues when finishing column resizing.
+            aoColumns[i].CRbSortableCache = aoColumns[i].bSortable;
+            aoColumns[i].bSortable = false;
+            // Disable Autowidth feature (now the user is in charge of setting column width so keeping this enabled looses changes after operations).
+            this.s.dt.oFeatures.bAutoWidth = false;
+            addEventsHandler();
+        }
+        else if (this.s.allowReorder) {
+            if (aoColumns[i].bReorderable === false) {
+                return false;
+            }
+
+            that.dom.resize = null;
+            /* Store information about the mouse position */
+            var target = $(e.target).closest('th, td');
+            var offset = target.offset();
+            var idx = parseInt( $(nTh).attr('data-column-index'), 10 );
+
+            if ( idx === undefined ) {
+                return;
+            }
+
+            this.s.mouse.startX = this._fnCursorPosition( e, 'pageX' );
+            this.s.mouse.startY = this._fnCursorPosition( e, 'pageY' );
+            this.s.mouse.offsetX = this._fnCursorPosition( e, 'pageX' ) - offset.left;
+            this.s.mouse.offsetY = this._fnCursorPosition( e, 'pageY' ) - offset.top;
+            this.s.mouse.target = this.s.dt.aoColumns[ idx ].nTh;
+            this.s.mouse.targetIndex = idx;
+            this.s.mouse.fromIndex = idx;
+
+            this._fnRegions();
+            addEventsHandler();
+        }
+
+    },
+
+
+    /**
+     * Deal with a mouse move event while dragging a node
+     *  @method  _fnMouseMove
+     *  @param   event e Mouse event
+     *  @param   colResized Index of the column that's being dragged or resized (index within the internal model, not the visible order)
+     *  @returns void
+     *  @private
+     */
+    "_fnMouseMove": function ( e, colResized )
+    {
+        var that = this;
+
+        // Handle column resizing.
+        if(this.dom.resize) {
+            // Since some columns might have been hidden, find the correct one to resize in the table's body
+            var currentColumnIndex;
+            var visibleColumnIndex = -1;
+            for(currentColumnIndex=-1; currentColumnIndex < this.s.dt.aoColumns.length-1 && currentColumnIndex != colResized; currentColumnIndex++) {
+                if(this.s.dt.aoColumns[currentColumnIndex+1].bVisible) {
+                    visibleColumnIndex++;
+                }
+            }
+            visibleColumnIndex++;
+
+            var $nTh = $(this.s.mouse.resizeElem);
+            var $nThNext = $($nTh.next('th'));
+            var $body = $(this.s.dt.nTBody);
+            var $head = $(this.s.dt.nTHead);
+
+               var nThInnerWidth = $nTh.first().innerWidth();
+            var nThNextInnerWidth = $nThNext.first().innerWidth();
+
+            var moveLength = e.pageX-this.s.mouse.startX;
+            var nThWidth = parseInt(this.s.mouse.startWidth + moveLength);
+            var nThNextWidth = parseInt(this.s.mouse.nextStartWidth - moveLength);
+
+            var scrollXEnabled = this.s.dt.oInit.sScrollX !== undefined;
+            var scrollYEnabled = this.s.dt.oInit.sScrollY !== undefined;
+
+            // Smart scrolling is not enabled.
+            if(!scrollXEnabled && !scrollYEnabled) {
+                if(moveLength < 0) {
+                    // Hack to calculate the minimum width of the column based on contents.
+                    $nTh.width('1%');
+                    var minNThWidth = $nTh.width();
+                    $nTh.width(this.s.mouse.startWidth);
+
+                    if(nThWidth >= minNThWidth) {
+                        $nTh.width(nThWidth);
+                    }
+                    else {
+                        $nTh.width(minNThWidth);
+                    }
+                }
+                else {
+                    // Hack to calculate the minimum width of the column based on contents.
+                    $nThNext.width('1%');
+                    var minNThNextWidth = $nThNext.width();
+                    $nThNext.width(this.s.mouse.nextStartWidth);
+
+                    if(nThNextInnerWidth <= minNThNextWidth) { return; }
+
+                    $nTh.width(nThWidth);
+                }
+            }
+            // Smart scrolling is enabled.
+            else {
+                // Keep the current table's width (used in case sScrollX is enabled to resize the whole table, giving an Excel-like behavior)
+                var $scrollHead = $(this.s.dt.nScrollHead);
+                var $scrollBody = $(this.s.dt.nScrollBody);
+
+                // Keep the current table's width (used in case sScrollX is enabled to resize the whole table, giving an Excel-like behavior)
+                if(scrollXEnabled) {
+                    var $scrollHeadInner = $scrollHead.find('div.dataTables_scrollHeadInner');
+                    var $scrollHeadTableWrapper = $(this.s.dt.nTableWrapper);
+                    if((this.table_size === undefined || this.table_size < 0) && $scrollHeadTableWrapper.length > 0) {
+                        this.table_size = $($scrollHead[0].childNodes[0].childNodes[0]).width();
+                    }
+
+                    if(this.table_size + moveLength > $scrollHeadTableWrapper.width()) {
+                        // Resize the header too (if sScrollX is enabled).
+                        if($scrollHeadTableWrapper.length) {
+                            $($scrollHeadTableWrapper[0].childNodes[0].childNodes[0]).width(this.table_size + moveLength);
+                        }
+                        $($scrollHeadInner).width(this.table_size + moveLength);
+
+                        // Resize the table too (if sScrollX is enabled).
+                        var new_table_size = this.table_size;
+                        if(this.table_size + moveLength > $scrollHeadTableWrapper.width()) {
+                            new_table_size += moveLength;
+                        }
+                        $scrollBody.closest('.dataTables_scroll').find('.dataTables_scrollHead table').first().width(new_table_size);
+                        $scrollBody.closest('.dataTables_scroll').find('.dataTables_scrollBody table').first().width(new_table_size);
+                    }
+                }
+
+                // When resizing the header, also resize the table's body (when enabling the Scroller, the table's header and
+                // body are split into different tables, so the column resizing doesn't work anymore).
+                // Since some columns might have been hidden, find the correct one to resize in the table's body
+
+                // Get the first row in the scrollBody thead.
+                var $scrollBodyTheadTr = $scrollBody.find('thead').first('tr');
+                var $scrollBodyNTh = $scrollBodyTheadTr.find('th:nth-child('+visibleColumnIndex+')');
+                var $scrollBodyNThNext = $scrollBodyTheadTr.find('th:nth-child('+(visibleColumnIndex+1)+')');
+                var $scrollBodyThSizing = $scrollBodyNTh.find('.dataTables_sizing');
+                var $scrollBodyThNextSizing = $scrollBodyNThNext.find('.dataTables_sizing');
+
+                // Get the first row in the scrollBody tbody.
+                var $scrollBodyTbodyTr = $scrollBody.find('tbody').first('tr');
+                var $scrollBodyNTd = $scrollBodyTbodyTr.find('td:nth-child('+visibleColumnIndex+')');
+                var $scrollBodyNTdNext = $scrollBodyTbodyTr.find('td:nth-child('+(visibleColumnIndex+1)+')');
+
+                if(moveLength < 0) {
+                    // Hack to calculate the minimum width of the column based on contents.
+                    $scrollBodyNTh.width('1%');
+                    var minNThWidth = $scrollBodyNTh.width();
+                    $scrollBodyNTh.width(this.s.mouse.startWidth);
+
+                    if(nThWidth >= minNThWidth) {
+                        $nTh.width(nThWidth);
+                        $scrollBodyNTh.width(nThWidth);
+                    }
+                    else {
+                        $nTh.width(minNThWidth);
+                        $scrollBodyNTh.width(minNThWidth);
+                    }
+                }
+                else {
+                    // Hack to calculate the minimum width of the column based on contents.
+                    $scrollBodyNThNext.width('1%');
+                    var minNThNextWidth = $scrollBodyNThNext.width();
+                    $scrollBodyNThNext.width(this.s.mouse.nextStartWidth);
+
+                    if($scrollBodyNThNext.width() <= minNThNextWidth) { return; }
+
+                    $nTh.width(nThWidth);
+                    $scrollBodyNTh.width(nThWidth);
+                }
+            }
+        }
+        else if(this.s.allowReorder) {
+            if( this.dom.drag === null ) {
+                /* Only create the drag element if the mouse has moved a specific distance from the start
+                 * point - this allows the user to make small mouse movements when sorting and not have a
+                 * possibly confusing drag element showing up
+                 */
+                if ( Math.pow(
+                    Math.pow(this._fnCursorPosition( e, 'pageX') - this.s.mouse.startX, 2) +
+                        Math.pow(this._fnCursorPosition( e, 'pageY') - this.s.mouse.startY, 2), 0.5 ) < 5 )
+                {
+                    return;
+                }
+                this._fnCreateDragNode();
+            }
+
+            /* Position the element - we respect where in the element the click occured */
+            this.dom.drag.css( {
+                left: this._fnCursorPosition( e, 'pageX' ) - this.s.mouse.offsetX,
+                top: this._fnCursorPosition( e, 'pageY' ) - this.s.mouse.offsetY
+            } );
+
+            /* Based on the current mouse position, calculate where the insert should go */
+            var bSet = false;
+            var lastToIndex = this.s.mouse.toIndex;
+
+            for ( var i=1, iLen=this.s.aoTargets.length ; i<iLen ; i++ )
+            {
+                if ( this._fnCursorPosition(e, 'pageX') < this.s.aoTargets[i-1].x + ((this.s.aoTargets[i].x-this.s.aoTargets[i-1].x)/2) )
+                {
+                    this.dom.pointer.css( 'left', this.s.aoTargets[i-1].x );
+                    this.s.mouse.toIndex = this.s.aoTargets[i-1].to;
+                    bSet = true;
+                    break;
+                }
+            }
+
+            // The insert element wasn't positioned in the array (less than
+            // operator), so we put it at the end
+            if ( !bSet )
+            {
+                this.dom.pointer.css( 'left', this.s.aoTargets[this.s.aoTargets.length-1].x );
+                this.s.mouse.toIndex = this.s.aoTargets[this.s.aoTargets.length-1].to;
+            }
+
+            // Perform reordering if realtime updating is on and the column has moved
+            if ( this.s.init.bRealtime && lastToIndex !== this.s.mouse.toIndex ) {
+                this.s.dt.oInstance.fnColReorder( this.s.mouse.fromIndex, this.s.mouse.toIndex, false );
+                this.s.mouse.fromIndex = this.s.mouse.toIndex;
+                this._fnRegions();
+            }
+        }
+    },
+
+
+    /**
+     * Finish off the mouse drag and insert the column where needed
+     *  @method  _fnMouseUp
+     *  @param   event e Mouse event
+     *  @param colResized The index of the column that was just dragged or resized (index within the internal model, not the visible order).
+     *  @returns void
+     *  @private
+     */
+    "_fnMouseUp": function ( e, colResized)
+    {
+        var that = this;
+
+        $(document).off('.ColReorder');
+
+        if ( this.dom.drag !== null )
+        {
+            /* Remove the guide elements */
+            this.dom.drag.remove();
+            this.dom.pointer.remove();
+            this.dom.drag = null;
+            this.dom.pointer = null;
+
+            /* Actually do the reorder */
+            this.s.dt.oInstance.fnColReorder( this.s.mouse.fromIndex, this.s.mouse.toIndex, true );
+            this._fnSetColumnIndexes();
+
+            /* When scrolling we need to recalculate the column sizes to allow for the shift */
+            if ( this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "" )
+            {
+                this.s.dt.oInstance.fnAdjustColumnSizing( false );
+            }
+
+            // Re-initialize so as to register the new column order (otherwise the events remain bound to the original column indices).
+            this._fnConstruct();
+
+            this.s.dt.oInstance.trigger('column-reorder.dt.mouseup', [ this.s.dt ] );
+
+            /* Save the state */
+            this.s.dt.oInstance.oApi._fnSaveState( this.s.dt );
+
+            if ( this.s.reorderCallback !== null )
+            {
+                this.s.reorderCallback.call( this );
+            }
+        }
+        else if(this.dom.resize !== null) {
+            var i;
+            var j;
+            var currentColumn;
+            var nextVisibleColumnIndex;
+            var previousVisibleColumnIndex;
+            var scrollXEnabled;
+
+            //Re-enable column sorting
+            this.s.dt.aoColumns[colResized].bSortable = this.s.dt.aoColumns[colResized].CRbSortableCache;
+
+            //Save the new resized column's width
+            this.s.dt.aoColumns[colResized].sWidth = $(this.s.mouse.resizeElem).width() + "px";
+
+            //If other columns might have changed their size, save their size too
+            scrollXEnabled = this.s.dt.oInit.sScrollX === "" ? false : true;
+            if(!scrollXEnabled) {
+                //The colResized index (internal model) here might not match the visible index since some columns might have been hidden
+                for(nextVisibleColumnIndex=colResized+1; nextVisibleColumnIndex < this.s.dt.aoColumns.length; nextVisibleColumnIndex++) {
+                    if(this.s.dt.aoColumns[nextVisibleColumnIndex].bVisible) {
+                        break;
+                    }
+                }
+
+                for(previousVisibleColumnIndex=colResized-1; previousVisibleColumnIndex >= 0; previousVisibleColumnIndex--) {
+                    if(this.s.dt.aoColumns[previousVisibleColumnIndex].bVisible) {
+                        break;
+                    }
+                }
+
+                if(this.s.dt.aoColumns.length > nextVisibleColumnIndex) {
+                    this.s.dt.aoColumns[nextVisibleColumnIndex].sWidth = $(this.s.mouse.resizeElem).next().width() + "px";
+                }
+                // The column resized is the right-most, so save the sizes of all the columns at the left
+                else {
+                    currentColumn = this.s.mouse.resizeElem;
+                    for(i = previousVisibleColumnIndex; i > 0; i--) {
+                        if(this.s.dt.aoColumns[i].bVisible) {
+                            currentColumn = $(currentColumn).prev();
+                            this.s.dt.aoColumns[i].sWidth = $(currentColumn).width() + "px";
+                        }
+                    }
+                }
+            }
+
+            // Update the internal storage of the table's width (in case we changed it because the user resized some column and scrollX was enabled
+            if(scrollXEnabled && $(this.s.dt.nScrollHead, this.s.dt.nTableWrapper) != undefined){
+                if($(this.s.dt.nScrollHead, this.s.dt.nTableWrapper).length > 0)
+                    this.table_size = $($(this.s.dt.nScrollHead, this.s.dt.nTableWrapper)[0].childNodes[0].childNodes[0]).width();
+            }
+
+            this.s.dt.oInstance.trigger('column-resize.dt.mouseup', [ this.s.dt ] );
+
+            /* Save the state */
+            this.s.dt.oInstance.oApi._fnSaveState( this.s.dt );
+
+            /* When scrolling we need to recalculate the column sizes to allow for the shift */
+            if (scrollXEnabled && (this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "" ))
+            {
+                this.s.dt.oInstance.fnAdjustColumnSizing( false );
+            }
+
+            if ( this.s.resizeCallback !== null )
+            {
+                this.s.resizeCallback.call( this );
+            }
+        }
+
+        this.dom.resize = null;
+    },
+
+
+    /**
+     * Calculate a cached array with the points of the column inserts, and the
+     * 'to' points
+     *  @method  _fnRegions
+     *  @returns void
+     *  @private
+     */
+    "_fnRegions": function ()
+    {
+        var aoColumns = this.s.dt.aoColumns;
+
+        this.s.aoTargets.splice( 0, this.s.aoTargets.length );
+
+        this.s.aoTargets.push( {
+            "x":  $(this.s.dt.nTable).offset().left,
+            "to": 0
+        } );
+
+        var iToPoint = 0;
+        var total = this.s.aoTargets[0].x;
+
+        for ( var i=0, iLen=aoColumns.length ; i<iLen ; i++ )
+        {
+            /* For the column / header in question, we want it's position to remain the same if the
+             * position is just to it's immediate left or right, so we only increment the counter for
+             * other columns
+             */
+            if ( i != this.s.mouse.fromIndex )
+            {
+                iToPoint++;
+            }
+
+            if ( aoColumns[i].bVisible && aoColumns[i].nTh.style.display !=='none' )
+            {
+                total += $(aoColumns[i].nTh).outerWidth();
+
+                this.s.aoTargets.push( {
+                    "x":  total,
+                    "to": iToPoint
+                } );
+            }
+        }
+
+        /* Disallow columns for being reordered by drag and drop, counting right to left */
+        if ( this.s.fixedRight !== 0 )
+        {
+            this.s.aoTargets.splice( this.s.aoTargets.length - this.s.fixedRight );
+        }
+
+        /* Disallow columns for being reordered by drag and drop, counting left to right */
+        if ( this.s.fixed !== 0 )
+        {
+            this.s.aoTargets.splice( 0, this.s.fixed );
+        }
+    },
+
+
+    /**
+     * Copy the TH element that is being drags so the user has the idea that they are actually
+     * moving it around the page.
+     *  @method  _fnCreateDragNode
+     *  @returns void
+     *  @private
+     */
+    "_fnCreateDragNode": function ()
+    {
+        var scrolling = this.s.dt.oScroll.sX !== "" || this.s.dt.oScroll.sY !== "";
+
+        var origCell = this.s.dt.aoColumns[ this.s.mouse.targetIndex ].nTh;
+        var origTr = origCell.parentNode;
+        var origThead = origTr.parentNode;
+        var origTable = origThead.parentNode;
+        var cloneCell = $(origCell).clone();
+
+        // This is a slightly odd combination of jQuery and DOM, but it is the
+        // fastest and least resource intensive way I could think of cloning
+        // the table with just a single header cell in it.
+        this.dom.drag = $(origTable.cloneNode(false))
+            .addClass( this.s.classNameClonedTable )
+            .append(
+                $(origThead.cloneNode(false)).append(
+                    $(origTr.cloneNode(false)).append(
+                        cloneCell[0]
+                    )
+                )
+            )
+            .css( {
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: $(origCell).outerWidth(),
+                height: $(origCell).outerHeight()
+            } )
+            .appendTo( 'body' );
+
+        this.dom.pointer = $('<div></div>')
+            .addClass( this.s.classNamePointer )
+            .css( {
+                position: 'absolute',
+                top: scrolling ?
+                    $('div.dataTables_scroll', this.s.dt.nTableWrapper).offset().top :
+                    $(this.s.dt.nTable).offset().top,
+                height : scrolling ?
+                    $('div.dataTables_scroll', this.s.dt.nTableWrapper).height() :
+                    $(this.s.dt.nTable).height()
+            } )
+            .appendTo( 'body' );
+    },
+
+
+    /**
+     * Add a data attribute to the column headers, so we know the index of
+     * the row to be reordered. This allows fast detection of the index, and
+     * for this plug-in to work with FixedHeader which clones the nodes.
+     *  @private
+     */
+    "_fnSetColumnIndexes": function ()
+    {
+        $.each( this.s.dt.aoColumns, function (i, column) {
+            $(column.nTh).attr('data-column-index', i);
+        } );
+    },
+
+
+    /**
+     * Get cursor position regardless of mouse or touch input
+     * @param  {Event}  e    jQuery Event
+     * @param  {string} prop Property to get
+     * @return {number}      Value
+     */
+    _fnCursorPosition: function ( e, prop ) {
+        if ( e.type.indexOf('touch') !== -1 ) {
+            return e.originalEvent.touches[0][ prop ];
+        }
+        return e[ prop ];
+    }
+} );
+
+
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Static parameters
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/**
+ * ColReorder default settings for initialisation
+ *  @namespace
+ *  @static
+ */
+ColReorder.defaults = {
+    /**
+     * Predefined ordering for the columns that will be applied automatically
+     * on initialisation. If not specified then the order that the columns are
+     * found to be in the HTML is the order used.
+     *  @type array
+     *  @default null
+     *  @static
+     */
+    aiOrder: null,
+
+    /**
+     * Redraw the table's column ordering as the end user draws the column
+     * (`true`) or wait until the mouse is released (`false` - default). Note
+     * that this will perform a redraw on each reordering, which involves an
+     * Ajax request each time if you are using server-side processing in
+     * DataTables.
+     *  @type boolean
+     *  @default false
+     *  @static
+     */
+    bRealtime: true,
+
+    /**
+     * Indicate how many columns should be fixed in position (counting from the
+     * left). This will typically be 1 if used, but can be as high as you like.
+     *  @type int
+     *  @default 0
+     *  @static
+     */
+    iFixedColumnsLeft: 0,
+
+    /**
+     * As `iFixedColumnsRight` but counting from the right.
+     *  @type int
+     *  @default 0
+     *  @static
+     */
+    iFixedColumnsRight: 0,
+
+    /**
+     * Callback function that is fired when columns are reordered. The `column-
+     * reorder` event is preferred over this callback
+     *  @type function():void
+     *  @default null
+     *  @static
+     */
+    fnReorderCallback: null,
+
+    /**
+     * Callback function that is fired when columns are resized. The `column-
+     * resize` event is preferred over this callback
+     *  @type function():void
+     *  @default null
+     *  @static
+     */
+    fnResizeCallback: null,
+
+    /**
+     * Allow Reorder functionnality
+     *  @property allowReorder
+     *  @type     boolean
+     *  @default  true
+     */
+    allowReorder: true,
+
+    /**
+     * Allow Resize functionnality
+     *  @property allowResize
+     *  @type     boolean
+     *  @default  true
+     */
+    allowResize: true,
+
+    /**
+     * Classname added to cloned element
+     *  @type string
+     *  @default 'DTCR_clonedTable'
+     *  @static
+     */
+    classNameClonedTable: 'DTCR_clonedTable',
+
+    /**
+     * Classname added to the cloned element wrapper
+     *  @type string
+     *  @default 'DTCR_pointer'
+     *  @static
+     */
+    classNamePointer: 'DTCR_pointer',
+
+    /**
+     * Classname added to the resizable th
+     *  @type string
+     *  @default 'DTCR_tableHeader'
+     *  @static
+     */
+    classNameTableHeader: 'DTCR_tableHeader',
+
+    /**
+     * Classname added to the resizable th when hovered
+     *  @type string
+     *  @default 'DTCR_tableHeaderHover'
+     *  @static
+     */
+    classNameTableHeaderHover: 'DTCR_tableHeaderHover'
+};
+
+
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Constants
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/**
+ * ColReorder version
+ *  @constant  version
+ *  @type      String
+ *  @default   As code
+ */
+ColReorder.version = "1.3.3";
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * DataTables interfaces
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+// Expose
+$.fn.dataTable.ColReorder = ColReorder;
+$.fn.DataTable.ColReorder = ColReorder;
+
+
+// Register a new feature with DataTables
+if ( typeof $.fn.dataTable == "function" &&
+     typeof $.fn.dataTableExt.fnVersionCheck == "function" &&
+     $.fn.dataTableExt.fnVersionCheck('1.10.8') )
+{
+    $.fn.dataTableExt.aoFeatures.push( {
+        "fnInit": function( settings ) {
+            var table = settings.oInstance;
+
+            if ( ! settings._colReorder ) {
+                var dtInit = settings.oInit;
+                var opts = dtInit.colReorder || dtInit.oColReorder || {};
+
+                new ColReorder( settings, opts );
+            }
+            else {
+                table.oApi._fnLog( settings, 1, "ColReorder attempted to initialise twice. Ignoring second" );
+            }
+
+            return null; /* No node for DataTables to insert */
+        },
+        "cFeature": "R",
+        "sFeature": "ColReorder"
+    } );
+}
+else {
+    alert( "Warning: ColReorder requires DataTables 1.10.8 or greater - www.datatables.net/download");
+}
+
+
+// Attach a listener to the document which listens for DataTables initialisation
+// events so we can automatically initialise
+$(document).on( 'preInit.dt.colReorder', function (e, settings) {
+    if ( e.namespace !== 'dt' ) {
+        return;
+    }
+
+    var init = settings.oInit.colReorder;
+    var defaults = DataTable.defaults.colReorder;
+
+    if ( init || defaults ) {
+        var opts = $.extend( {}, init, defaults );
+
+        if ( init !== false ) {
+            new ColReorder( settings, opts  );
+        }
+    }
+} );
+
+
+// API augmentation
+$.fn.dataTable.Api.register( 'colReorder.reset()', function () {
+    return this.iterator( 'table', function ( ctx ) {
+        ctx._colReorder.fnReset();
+    } );
+} );
+
+$.fn.dataTable.Api.register( 'colReorder.order()', function ( set, original ) {
+    if ( set ) {
+        return this.iterator( 'table', function ( ctx ) {
+            ctx._colReorder.fnOrder( set, original );
+        } );
+    }
+
+    return this.context.length ?
+        this.context[0]._colReorder.fnOrder() :
+        null;
+} );
+
+$.fn.dataTable.Api.register( 'colReorder.transpose()', function ( idx, dir ) {
+    return this.context.length && this.context[0]._colReorder ?
+        this.context[0]._colReorder.fnTranspose( idx, dir ) :
+        idx;
+} );
+
+
+return ColReorder;
+}));

--- a/ckanext/tableview/templates/datatables_view.html
+++ b/ckanext/tableview/templates/datatables_view.html
@@ -45,6 +45,7 @@
   </table>
 
   {% resource 'tableview/main' %}
+  {% resource 'tableview/' + h.tableview_theme() %}
 {% endblock %}
 
 {% block styles %}{% endblock %}

--- a/ckanext/tableview/templates/datatables_view.html
+++ b/ckanext/tableview/templates/datatables_view.html
@@ -21,7 +21,7 @@
       {% endif %}
       data-fixed-header="true"
       data-fixed-columns="true"
-      data-dom='"Blifrtip"'
+      data-dom='"RfBirtilp"'
       data-buttons='[
         {
           "extend": "colvis",

--- a/ckanext/tableview/templates/datatables_view.html
+++ b/ckanext/tableview/templates/datatables_view.html
@@ -45,7 +45,11 @@
   </table>
 
   {% resource 'tableview/main' %}
-  {% resource 'tableview/' + h.tableview_theme() %}
+
+  {% set theme_value = h.tableview_theme() %}
+  {% if theme_value != 'None' %}
+    {% resource 'tableview/' + theme_value %}
+  {% endif %}
 {% endblock %}
 
 {% block styles %}{% endblock %}


### PR DESCRIPTION
- [x] In progress of finalizing the theme for justicehub

- [x] Replace default theme with if condition, if theme is not none, then add resources else go with default styling

- [x] Fit table in iframe without scroll

- [x] Ability to resize column width and reorder it

- [x] Move Show entries section at right

### Theme

default_theme:

![Screenshot from 2020-10-13 15-45-20](https://user-images.githubusercontent.com/9320644/95850080-e638a380-0d6d-11eb-934f-60b676751485.png)

justicehub_theme:

![Screenshot from 2020-10-13 01-16-15](https://user-images.githubusercontent.com/9320644/95784592-be0b5f00-0cf1-11eb-86eb-f7c645c55095.png)

*Updated JH theme*

![Screenshot from 2020-10-14 17-07-23](https://user-images.githubusercontent.com/9320644/95983729-c5408300-0e3f-11eb-9156-d0e2b578bdab.png)



